### PR TITLE
キー押下を発火する機能の追加

### DIFF
--- a/raincoat/Domains/Services/SerialPortService.cs
+++ b/raincoat/Domains/Services/SerialPortService.cs
@@ -62,7 +62,7 @@ namespace raincoat.Domains.Services
             }
             catch (Exception ex)
             {
-                throw new ApplicationException("JSONデータの解析中にエラーが発生しました", ex);
+                MessageBox.Show($"JSONデータの解析中にエラーが発生しました:\n{ex.Message}\n{ex.StackTrace}");
             }
         }
     }

--- a/raincoat/Domains/Services/SkillService.cs
+++ b/raincoat/Domains/Services/SkillService.cs
@@ -28,6 +28,9 @@ namespace raincoat.Domains.Services
                 case SkillType.RunProgram:
                     result = new ExceptionHandlingDecorator<SkillInputPack, SkillOutputPack>(new StartProgram());
                     break;
+                case SkillType.KeyStroke:
+                    result = new ReduceKeystrokes();
+                    break;
                 default:
                     result = new Continue();
                     break;

--- a/raincoat/Domains/ValueObjects/SkillType.cs
+++ b/raincoat/Domains/ValueObjects/SkillType.cs
@@ -22,5 +22,9 @@ namespace raincoat.Domains.ValueObjects
         /// プログラム実行
         /// </summary>
         RunProgram = 4,
+        /// <summary>
+        /// キー押下
+        /// </summary>
+        KeyStroke = 5,
     }
 }

--- a/raincoat/Infrastructures/Repositories/IRepository.cs
+++ b/raincoat/Infrastructures/Repositories/IRepository.cs
@@ -1,0 +1,6 @@
+﻿namespace raincoat.Infrastructures.Repositories
+{
+    public interface IRepository
+    {
+    }
+}

--- a/raincoat/Infrastructures/Repositories/SkillItemsRepository.cs
+++ b/raincoat/Infrastructures/Repositories/SkillItemsRepository.cs
@@ -3,7 +3,7 @@ using System.Data;
 
 namespace raincoat.Infrastructures.Repositories
 {
-    public class SkillItemsRepository
+    public class SkillItemsRepository : IRepository
     {
         private readonly DataTable SkillItems = new("SkillItems");
 

--- a/raincoat/Infrastructures/Repositories/SkillItemsRepository.cs
+++ b/raincoat/Infrastructures/Repositories/SkillItemsRepository.cs
@@ -17,6 +17,7 @@ namespace raincoat.Infrastructures.Repositories
             this.SkillItems.Rows.Add((int)SkillType.BeginStream, "配信開始");
             this.SkillItems.Rows.Add((int)SkillType.EndStream, "配信終了");
             this.SkillItems.Rows.Add((int)SkillType.RunProgram, "パス起動");
+            this.SkillItems.Rows.Add((int)SkillType.KeyStroke, "キーを押す");
         }
 
         public DataGridViewComboBoxColumn GetDataGridViewComboBoxColumn()

--- a/raincoat/Infrastructures/Repositories/VirtualKeyRepository.cs
+++ b/raincoat/Infrastructures/Repositories/VirtualKeyRepository.cs
@@ -1,0 +1,127 @@
+﻿namespace raincoat.Infrastructures.Repositories
+{
+    public class VirtualKeyRepository : IRepository
+    {
+        private readonly HashSet<char> symbolsRequiringShift = new HashSet<char>
+        {
+            '!',
+            '"',
+            '#',
+            '$',
+            '%',
+            '&',
+            '(',
+            ')',
+            '*',
+            '+',
+            '<',
+            '=',
+            '>',
+            '?',
+            '\'',
+            '_',
+            '`',
+            '{',
+            '}',
+            '~',
+        };
+
+        private readonly Dictionary<char, byte> charToVirtualKey = new Dictionary<char, byte>
+        {
+            { ' ', 0x20 },
+            { '!', 0x31 },
+            { '"', 0x32 },
+            { '#', 0x33 },
+            { '$', 0x34 },
+            { '%', 0x35 },
+            { '&', 0x36 },
+            { '(', 0x38 },
+            { ')', 0x39 },
+            { '*', 0xBA },
+            { '+', 0xBB },
+            { ',', 0xBC },
+            { '-', 0xBD },
+            { '.', 0xBE },
+            { '/', 0xBF },
+            { ':', 0xBA },
+            { ';', 0xBB },
+            { '<', 0xBC },
+            { '=', 0xBD },
+            { '>', 0xBE },
+            { '?', 0xBF },
+            { '@', 0xC0 },
+            { '[', 0xDB },
+            { '\'', 0x37 },
+            { '\\', 0xE2 },
+            { ']', 0xDD },
+            { '^', 0xDE },
+            { '_', 0xE2 },
+            { '`', 0xC0 },
+            { '{', 0xDB },
+            { '|', 0xDC },
+            { '}', 0xDD },
+            { '~', 0xDE },
+        };
+
+        private static Dictionary<string, byte> stringToVirtualKey = new Dictionary<string, byte>
+        {
+            { "F1", 0x70 },
+            { "F2", 0x71 },
+            { "F3", 0x72 },
+            { "F4", 0x73 },
+            { "F5", 0x74 },
+            { "F6", 0x75 },
+            { "F7", 0x76 },
+            { "F8", 0x77 },
+            { "F9", 0x78 },
+            { "F10", 0x79 },
+            { "F11", 0x7A },
+            { "F12", 0x7B },
+            { "Insert", 0x2D },
+            { "Delete", 0x2E },
+            { "Home", 0x24 },
+            { "End", 0x23 },
+            { "PageUp", 0x21 },
+            { "PageDown", 0x22 },
+            { "Up", 0x26 },
+            { "Down", 0x28 },
+            { "Left", 0x25 },
+            { "Right", 0x27 }
+        };
+
+        public byte GetVirtualKey(char c)
+        {
+            if (charToVirtualKey.TryGetValue(c, out byte virtualKey))
+            {
+                return virtualKey;
+            }
+
+            if (char.IsLetter(c))
+            {
+                return (byte)char.ToUpper(c);
+            }
+
+            if (char.IsNumber(c))
+            {
+                return (byte)(c + 0x30);
+            }
+
+            throw new ArgumentException($"Invalid character: {c}");
+        }
+
+        public byte GetVirtualKey(string keyName)
+        {
+            if (stringToVirtualKey.TryGetValue(keyName, out byte virtualKey))
+            {
+                return virtualKey;
+            }
+
+            throw new ArgumentException($"Invalid key name: {keyName}");
+        }
+
+        public bool IsShiftRequiredForSymbol(char c)
+        {
+            return this.symbolsRequiringShift.Contains(c) || char.IsUpper(c);
+        }
+    }
+}

--- a/raincoat/UseCases/Skills/ReduceKeystrokes.cs
+++ b/raincoat/UseCases/Skills/ReduceKeystrokes.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 namespace raincoat.UseCases.Skills
@@ -14,15 +15,17 @@ namespace raincoat.UseCases.Skills
         public SkillOutputPack Execute(SkillInputPack input)
         {
             var strokes = input.Argument;
-            foreach (string stroke in Regex.Split(strokes, @"(?=<[^>]+>)"))
+            foreach (string stroke in Regex.Split(strokes, @"((?<!\\)<[^<>]+>|\\[^<>]+)"))
             {
                 if (stroke.StartsWith("<"))
                 {
                     this.SimulateSpecialKey(stroke);
+                    continue;
                 }
-                else
+
+                foreach (char c in stroke)
                 {
-                    foreach (char c in stroke)
+                    if (c != '\\')
                     {
                         this.SimulateKeyPress(c);
                     }
@@ -34,20 +37,70 @@ namespace raincoat.UseCases.Skills
 
         private void SimulateKeyPress(char c)
         {
-            byte virtualKey = (byte)char.ToUpper(c);
+            byte virtualKey;
             bool isUpperCase = char.IsUpper(c);
+            bool isLowerCase = char.IsLower(c);
 
             if (isUpperCase)
             {
+                virtualKey = (byte)c;
                 keybd_event((byte)0x10, 0, 0, 0); // SHIFT down
-            }
-
-            keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY, 0);
-            keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
-
-            if (isUpperCase)
-            {
+                keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY, 0);
+                keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
                 keybd_event((byte)0x10, 0, KEYEVENTF_KEYUP, 0); // SHIFT up
+            }
+            else if (isLowerCase)
+            {
+                virtualKey = (byte)char.ToUpper(c);
+                keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY, 0);
+                keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+            }
+            else
+            {
+                bool isDownShift;
+                // 記号の処理
+                switch (c)
+                {
+                    case ':': virtualKey = 0xBA; isDownShift = false; break;
+                    case ';': virtualKey = 0xBB; isDownShift = false; break;
+                    case ',': virtualKey = 0xBC; isDownShift = false; break;
+                    case '-': virtualKey = 0xBD; isDownShift = false; break;
+                    case '.': virtualKey = 0xBE; isDownShift = false; break;
+                    case '/': virtualKey = 0xBF; isDownShift = false; break;
+                    case '@': virtualKey = 0xC0; isDownShift = false; break;
+
+                    case '*': virtualKey = 0xBA; isDownShift = true; break;
+                    case '+': virtualKey = 0xBB; isDownShift = true; break;
+                    case '<': virtualKey = 0xBC; isDownShift = true; break;
+                    case '=': virtualKey = 0xBD; isDownShift = true; break;
+                    case '>': virtualKey = 0xBE; isDownShift = true; break;
+                    case '?': virtualKey = 0xBF; isDownShift = true; break;
+                    case '`': virtualKey = 0xC0; isDownShift = true; break;
+
+                    case '!': virtualKey = 0x31; isDownShift = true; break;
+                    case '"': virtualKey = 0x32; isDownShift = true; break;
+                    case '#': virtualKey = 0x33; isDownShift = true; break;
+                    case '$': virtualKey = 0x34; isDownShift = true; break;
+                    case '%': virtualKey = 0x35; isDownShift = true; break;
+                    case '&': virtualKey = 0x36; isDownShift = true; break;
+                    case '\'': virtualKey = 0x37; isDownShift = true; break;
+                    case '(': virtualKey = 0x38; isDownShift = true; break;
+                    case ')': virtualKey = 0x39; isDownShift = true; break;
+
+                    default: throw new ArgumentException("変なキーが設定されています。");
+                }
+                if (isDownShift)
+                {
+                    keybd_event(0x10, 0, 0, 0); // SHIFT down
+                    keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY, 0);
+                    keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+                    keybd_event(0x10, 0, KEYEVENTF_KEYUP, 0); // SHIFT up
+                }
+                else
+                {
+                    keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY, 0);
+                    keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+                }
             }
         }
 
@@ -58,22 +111,66 @@ namespace raincoat.UseCases.Skills
             bool isExtendedKey = false;
 
             // 修飾キーの処理
-            if (stroke.StartsWith("<S-"))
+            if (stroke.StartsWith("<S-") || stroke.StartsWith("<Shift>"))
             {
                 flags |= KEYEVENTF_EXTENDEDKEY;
                 keybd_event((byte)0x10, 0, 0, 0); // SHIFT down
             }
-            if (stroke.StartsWith("<C-"))
+            if (stroke.StartsWith("<C-") || stroke.StartsWith("<Ctrl>"))
             {
                 flags |= KEYEVENTF_EXTENDEDKEY;
                 keybd_event((byte)0x11, 0, 0, 0); // CTRL down
             }
+            if (stroke.StartsWith("<A-") || stroke.StartsWith("<Alt>"))
+            {
+                flags |= KEYEVENTF_EXTENDEDKEY;
+                keybd_event((byte)0x12, 0, 0, 0); // ALT down
+            }
 
             // キーコードの解析
-            string keyPart = stroke.Substring(stroke.IndexOf('-') + 1, stroke.Length - stroke.IndexOf('-') - 2);
+            string keyPart = stroke
+                .Substring(stroke.IndexOf('-') + 1)
+                .Replace("<", string.Empty)
+                .Replace(">", string.Empty);
+
+            Debug.WriteLine($"{stroke} => {keyPart}");
             if (keyPart.Length == 1)
             {
-                virtualKey = (byte)char.ToUpper(keyPart[0]);
+                char c = keyPart[0];
+                if (char.IsLetter(c))
+                {
+                    virtualKey = (byte)char.ToUpper(c);
+                }
+                else
+                {
+                    // 記号の処理
+                    switch (c)
+                    {
+                        case '<': virtualKey = 0xDB; break;
+                        case '>': virtualKey = 0xDC; break;
+                        case '?': virtualKey = 0xBF; break;
+                        case ',': virtualKey = 0xBC; break;
+                        case '.': virtualKey = 0xBE; break;
+                        case '/': virtualKey = 0xBF; break;
+                        case ';': virtualKey = 0xBA; break;
+                        case '\'': virtualKey = 0xDE; break;
+                        case '"': virtualKey = 0xDD; break;
+                        case '[': virtualKey = 0xDB; break;
+                        case ']': virtualKey = 0xDD; break;
+                        case '{': virtualKey = 0xDB; break;
+                        case '}': virtualKey = 0xDD; break;
+                        case '(': virtualKey = 0xDB; break;
+                        case ')': virtualKey = 0xDD; break;
+                        case '|': virtualKey = 0xDC; break;
+                        case '\\': virtualKey = 0xDC; break;
+                        case '`': virtualKey = 0xC0; break;
+                        case '~': virtualKey = 0xC0; break;
+                        case '-': virtualKey = 0xBD; break;
+                        case '=': virtualKey = 0xBB; break;
+                        case '+': virtualKey = 0xBB; break;
+                    }
+                    flags |= KEYEVENTF_EXTENDEDKEY;
+                }
             }
             else
             {
@@ -81,7 +178,27 @@ namespace raincoat.UseCases.Skills
                 switch (keyPart)
                 {
                     case "F1": virtualKey = 0x70; break;
-                        // 他の特殊キーの場合はここに追加
+                    case "F2": virtualKey = 0x71; break;
+                    case "F3": virtualKey = 0x72; break;
+                    case "F4": virtualKey = 0x73; break;
+                    case "F5": virtualKey = 0x74; break;
+                    case "F6": virtualKey = 0x75; break;
+                    case "F7": virtualKey = 0x76; break;
+                    case "F8": virtualKey = 0x77; break;
+                    case "F9": virtualKey = 0x78; break;
+                    case "F10": virtualKey = 0x79; break;
+                    case "F11": virtualKey = 0x7A; break;
+                    case "F12": virtualKey = 0x7B; break;
+                    case "Insert": virtualKey = 0x2D; break;
+                    case "Delete": virtualKey = 0x2E; break;
+                    case "Home": virtualKey = 0x24; break;
+                    case "End": virtualKey = 0x23; break;
+                    case "PageUp": virtualKey = 0x21; break;
+                    case "PageDown": virtualKey = 0x22; break;
+                    case "Up": virtualKey = 0x26; break;
+                    case "Down": virtualKey = 0x28; break;
+                    case "Left": virtualKey = 0x25; break;
+                    case "Right": virtualKey = 0x27; break;
                 }
             }
 
@@ -89,13 +206,17 @@ namespace raincoat.UseCases.Skills
             keybd_event(virtualKey, 0, flags | KEYEVENTF_KEYUP | (isExtendedKey ? KEYEVENTF_EXTENDEDKEY : (uint)0), 0);
 
             // 修飾キーの解放
-            if (stroke.StartsWith("<S-"))
+            if (stroke.StartsWith("<S-") || stroke.StartsWith("<Shift>"))
             {
                 keybd_event((byte)0x10, 0, KEYEVENTF_KEYUP, 0); // SHIFT up
             }
-            if (stroke.StartsWith("<C-"))
+            if (stroke.StartsWith("<C-") || stroke.StartsWith("<Ctrl>"))
             {
                 keybd_event((byte)0x11, 0, KEYEVENTF_KEYUP, 0); // CTRL up
+            }
+            if (stroke.StartsWith("<A-") || stroke.StartsWith("<Alt>"))
+            {
+                keybd_event((byte)0x12, 0, KEYEVENTF_KEYUP, 0); // ALT up
             }
         }
     }

--- a/raincoat/UseCases/Skills/ReduceKeystrokes.cs
+++ b/raincoat/UseCases/Skills/ReduceKeystrokes.cs
@@ -18,13 +18,13 @@ namespace raincoat.UseCases.Skills
             {
                 if (stroke.StartsWith("<"))
                 {
-                    SimulateSpecialKey(stroke);
+                    this.SimulateSpecialKey(stroke);
                 }
                 else
                 {
                     foreach (char c in stroke)
                     {
-                        SimulateKeyPress(c);
+                        this.SimulateKeyPress(c);
                     }
                 }
             }
@@ -35,8 +35,20 @@ namespace raincoat.UseCases.Skills
         private void SimulateKeyPress(char c)
         {
             byte virtualKey = (byte)char.ToUpper(c);
+            bool isUpperCase = char.IsUpper(c);
+
+            if (isUpperCase)
+            {
+                keybd_event((byte)0x10, 0, 0, 0); // SHIFT down
+            }
+
             keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY, 0);
             keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+
+            if (isUpperCase)
+            {
+                keybd_event((byte)0x10, 0, KEYEVENTF_KEYUP, 0); // SHIFT up
+            }
         }
 
         private void SimulateSpecialKey(string stroke)

--- a/raincoat/UseCases/Skills/ReduceKeystrokes.cs
+++ b/raincoat/UseCases/Skills/ReduceKeystrokes.cs
@@ -1,0 +1,90 @@
+﻿using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+
+namespace raincoat.UseCases.Skills
+{
+    internal class ReduceKeystrokes : IUseCase<SkillInputPack, SkillOutputPack>
+    {
+        [DllImport("user32.dll", SetLastError = true)]
+        static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, uint dwExtraInfo);
+
+        const int KEYEVENTF_EXTENDEDKEY = 0x0001;
+        const int KEYEVENTF_KEYUP = 0x0002;
+
+        public SkillOutputPack Execute(SkillInputPack input)
+        {
+            var strokes = input.Argument;
+            foreach (string stroke in Regex.Split(strokes, @"(?=<[^>]+>)"))
+            {
+                if (stroke.StartsWith("<"))
+                {
+                    SimulateSpecialKey(stroke);
+                }
+                else
+                {
+                    foreach (char c in stroke)
+                    {
+                        SimulateKeyPress(c);
+                    }
+                }
+            }
+
+            return new SkillOutputPack();
+        }
+
+        private void SimulateKeyPress(char c)
+        {
+            byte virtualKey = (byte)char.ToUpper(c);
+            keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY, 0);
+            keybd_event(virtualKey, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+        }
+
+        private void SimulateSpecialKey(string stroke)
+        {
+            byte virtualKey = 0;
+            uint flags = 0;
+            bool isExtendedKey = false;
+
+            // 修飾キーの処理
+            if (stroke.StartsWith("<S-"))
+            {
+                flags |= KEYEVENTF_EXTENDEDKEY;
+                keybd_event((byte)0x10, 0, 0, 0); // SHIFT down
+            }
+            if (stroke.StartsWith("<C-"))
+            {
+                flags |= KEYEVENTF_EXTENDEDKEY;
+                keybd_event((byte)0x11, 0, 0, 0); // CTRL down
+            }
+
+            // キーコードの解析
+            string keyPart = stroke.Substring(stroke.IndexOf('-') + 1, stroke.Length - stroke.IndexOf('-') - 2);
+            if (keyPart.Length == 1)
+            {
+                virtualKey = (byte)char.ToUpper(keyPart[0]);
+            }
+            else
+            {
+                isExtendedKey = true;
+                switch (keyPart)
+                {
+                    case "F1": virtualKey = 0x70; break;
+                        // 他の特殊キーの場合はここに追加
+                }
+            }
+
+            keybd_event(virtualKey, 0, flags | (isExtendedKey ? KEYEVENTF_EXTENDEDKEY : (uint)0), 0);
+            keybd_event(virtualKey, 0, flags | KEYEVENTF_KEYUP | (isExtendedKey ? KEYEVENTF_EXTENDEDKEY : (uint)0), 0);
+
+            // 修飾キーの解放
+            if (stroke.StartsWith("<S-"))
+            {
+                keybd_event((byte)0x10, 0, KEYEVENTF_KEYUP, 0); // SHIFT up
+            }
+            if (stroke.StartsWith("<C-"))
+            {
+                keybd_event((byte)0x11, 0, KEYEVENTF_KEYUP, 0); // CTRL up
+            }
+        }
+    }
+}


### PR DESCRIPTION
「キー押下を発火したい」というイシュー (#2) を解決するためのものです。このプルリクエストをマージすると、以下の機能が追加されます。

- キー押下をイベントとして発火できる機能
- Shiftキーで大文字を送信できる機能
- 記号や特殊なキーに対応する機能
- シリアルポートの例外をメッセージ表示に修正する機能
- 文字を仮想キーへ変換する処理を追加する機能
- リポジトリクラスを使用したコードに修正する機能